### PR TITLE
Use parameter instead of variable from the global scope

### DIFF
--- a/FunctionalProgramming.playground/Contents.swift
+++ b/FunctionalProgramming.playground/Contents.swift
@@ -10,7 +10,7 @@ let integers = Array(1...10)
 
 func evensImperative(from input: [Int]) -> [Int] {
     var evens: [Int] = []
-    for integer in integers {
+    for integer in input {
         if integer.isMultiple(of: 2) {
             evens.append(integer)
         }


### PR DESCRIPTION
Changed evensImperative function to use input parameter instead of global variable integers within function.  Still passes integers to function in example of calling it.